### PR TITLE
TEAMR-221 | handle Google Logging initialized twice

### DIFF
--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -62,14 +62,6 @@ TEST(PrintLogTest, LogTestWithInit) {
   RayLog::ShutDownRayLog();
 }
 
-TEST(PrintLogTest, LogTestWithInit) {
-  // Should fail if start twice
-  RayLog::StartRayLog("", RayLogLevel::DEBUG, ray::GetUserTempDir() + ray::GetDirSep());
-  RayLog::StartRayLog("", RayLogLevel::DEBUG, ray::GetUserTempDir() + ray::GetDirSep());
-  PrintLog();
-  RayLog::ShutDownRayLog();
-}
-
 // This test will output large amount of logs to stderr, should be disabled in travis.
 TEST(LogPerfTest, PerfTest) {
   RayLog::StartRayLog("/fake/path/to/appdire/LogPerfTest", RayLogLevel::ERROR,

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -62,6 +62,14 @@ TEST(PrintLogTest, LogTestWithInit) {
   RayLog::ShutDownRayLog();
 }
 
+TEST(PrintLogTest, LogTestWithInit) {
+  // Should fail if start twice
+  RayLog::StartRayLog("", RayLogLevel::DEBUG, ray::GetUserTempDir() + ray::GetDirSep());
+  RayLog::StartRayLog("", RayLogLevel::DEBUG, ray::GetUserTempDir() + ray::GetDirSep());
+  PrintLog();
+  RayLog::ShutDownRayLog();
+}
+
 // This test will output large amount of logs to stderr, should be disabled in travis.
 TEST(LogPerfTest, PerfTest) {
   RayLog::StartRayLog("/fake/path/to/appdire/LogPerfTest", RayLogLevel::ERROR,

--- a/thirdparty/patches/glog-stack-trace.patch
+++ b/thirdparty/patches/glog-stack-trace.patch
@@ -13,4 +13,17 @@ diff --git bazel/glog.bzl bazel/glog.bzl
          # For logging.cc.
          "-DHAVE_PREAD",
          "-DHAVE___ATTRIBUTE__",
+diff --git src/utilities.cc src/utilities.cc
+--- src/utilities.cc
++++ src/utilities.cc
+@@ -334,6 +334,9 @@ void SetCrashReason(const CrashReason* r) {
+ }
+ 
+ void InitGoogleLoggingUtilities(const char* argv0) {
++  if (IsGoogleLoggingInitialized()) {
++    ShutdownGoogleLoggingUtilities();
++  }
+   CHECK(!IsGoogleLoggingInitialized())
+       << "You called InitGoogleLogging() twice!";
+   const char* slash = strrchr(argv0, '/');
 -- 


### PR DESCRIPTION
ticket: https://hyperscience.atlassian.net/browse/TEAMR-221

This is a random error and we've only seen it once. Current workaround without patch is to restart the training.

For the error itself, I added a check when Google Logging is already initialized, shutdown the current one and re-initialize a new one. The update is done through a patch, applied during compilation of ray, because it works on the Google Logging library, which is a third-party dependency for ray. This patch is .

Because it's random error i'm not able to reproduce the error in training. So i tested this by manually called `InitGoogleLogging` twice, in `src/ray/util/logging.cc`, L155. As expected, it failed without this patch throwing same error as in the ticket, and works fine with the patch.


TODO:
- [ ] build wheel and update it to forms