### PR TITLE
MLE-771: Fix ray CI pipeline

### DIFF
--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -15,28 +15,16 @@ DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
 PY_VERSIONS=(
-#             "3.6.2"  MLE-771: Commenting out due to build failures and not required
-#             "3.7.0"
-#             "3.8.2"
              "3.9.1"
              "3.10.4")
 PY_INSTS=(
-#          "python-3.6.2-macosx10.6.pkg" MLE-771: Commenting out due to build failures and not required
-#          "python-3.7.0-macosx10.6.pkg"
-#          "python-3.8.2-macosx10.9.pkg"
           "python-3.9.1-macosx10.9.pkg"
           "python-3.10.4-macos11.pkg")
 PY_MMS=(
-#        "3.6" MLE-771: Commenting out due to build failures and not required
-#        "3.7"
-#        "3.8"
         "3.9"
         "3.10")
 
 NUMPY_VERSIONS=(
-#                "1.14.5" MLE-771: Commenting out due to build failures and not required
-#                "1.14.5"
-#                "1.14.5"
                 "1.19.3"
                 "1.22.0")
 
@@ -76,12 +64,10 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     INST_PATH=python_downloads/$PY_INST
     curl $MACPYTHON_URL/"$PY_VERSION"/"$PY_INST" > "$INST_PATH"
     sudo installer -pkg "$INST_PATH" -target /
-    sudo installer -pkg "$INST_PATH" -target /
 
     pushd /tmp
       # Install latest version of pip to avoid brownouts.
-      curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-      $PYTHON_EXE get-pip.py
+      curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && $PYTHON_EXE get-pip.py
     popd
   fi
 

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -34,7 +34,7 @@ PY_MMS=(
         "3.10")
 
 NUMPY_VERSIONS=(
-#                "1.14.5" MLE-771: Commenting out due to build failures and not required 
+#                "1.14.5" MLE-771: Commenting out due to build failures and not required
 #                "1.14.5"
 #                "1.14.5"
                 "1.19.3"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -15,26 +15,26 @@ DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
 PY_VERSIONS=(
-#             "3.6.2"
+#             "3.6.2"  MLE-771: Commenting out due to build failures and not required
 #             "3.7.0"
 #             "3.8.2"
              "3.9.1"
              "3.10.4")
 PY_INSTS=(
-#          "python-3.6.2-macosx10.6.pkg"
+#          "python-3.6.2-macosx10.6.pkg" MLE-771: Commenting out due to build failures and not required
 #          "python-3.7.0-macosx10.6.pkg"
 #          "python-3.8.2-macosx10.9.pkg"
           "python-3.9.1-macosx10.9.pkg"
           "python-3.10.4-macos11.pkg")
 PY_MMS=(
-#        "3.6"
+#        "3.6" MLE-771: Commenting out due to build failures and not required
 #        "3.7"
 #        "3.8"
         "3.9"
         "3.10")
 
 NUMPY_VERSIONS=(
-#                "1.14.5"
+#                "1.14.5" MLE-771: Commenting out due to build failures and not required 
 #                "1.14.5"
 #                "1.14.5"
                 "1.19.3"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Cause the script to exit if a single command fails.
-set -e
-
-# Show explicitly which commands are currently running.
-set -x
+# -e : exit if a single command fails
+# -x : output commands that are run
+set -ex
 
 # Much of this is taken from https://github.com/matthew-brett/multibuild.
 # This script uses "sudo", so you may need to type in a password a couple times.

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -14,25 +14,29 @@ MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
-PY_VERSIONS=("3.6.2"
-             "3.7.0"
-             "3.8.2"
+PY_VERSIONS=(
+#             "3.6.2"
+#             "3.7.0"
+#             "3.8.2"
              "3.9.1"
              "3.10.4")
-PY_INSTS=("python-3.6.2-macosx10.6.pkg"
-          "python-3.7.0-macosx10.6.pkg"
-          "python-3.8.2-macosx10.9.pkg"
+PY_INSTS=(
+#          "python-3.6.2-macosx10.6.pkg"
+#          "python-3.7.0-macosx10.6.pkg"
+#          "python-3.8.2-macosx10.9.pkg"
           "python-3.9.1-macosx10.9.pkg"
           "python-3.10.4-macos11.pkg")
-PY_MMS=("3.6"
-        "3.7"
-        "3.8"
+PY_MMS=(
+#        "3.6"
+#        "3.7"
+#        "3.8"
         "3.9"
         "3.10")
 
-NUMPY_VERSIONS=("1.14.5"
-                "1.14.5"
-                "1.14.5"
+NUMPY_VERSIONS=(
+#                "1.14.5"
+#                "1.14.5"
+#                "1.14.5"
                 "1.19.3"
                 "1.22.0")
 
@@ -72,11 +76,12 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     INST_PATH=python_downloads/$PY_INST
     curl $MACPYTHON_URL/"$PY_VERSION"/"$PY_INST" > "$INST_PATH"
     sudo installer -pkg "$INST_PATH" -target /
-    installer -pkg "$INST_PATH" -target /
+    sudo installer -pkg "$INST_PATH" -target /
 
     pushd /tmp
       # Install latest version of pip to avoid brownouts.
-      curl https://bootstrap.pypa.io/get-pip.py | $PYTHON_EXE
+      curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+      $PYTHON_EXE get-pip.py
     popd
   fi
 

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -35,14 +35,20 @@ echo "java_bin path $java_bin"
 java_home=${java_bin%jre/bin/java}
 export JAVA_HOME="$java_home"
 
-/ray/ci/env/install-bazel.sh
+WORK_DIR=${WORK_DIR:-}
+if [[ -z "${WORK_DIR}" ]]; then
+  echo "Project home not set"
+  WORK_DIR="/ray"
+fi
+
+$WORK_DIR/ci/env/install-bazel.sh
 # Put bazel into the PATH if building Bazel from source
 # export PATH=/root/bazel-3.2.0/output:$PATH:/root/bin
 
 # If converting down to manylinux2010, the following configuration should
 # be set for bazel
 #echo "build --config=manylinux2010" >> /root/.bazelrc
-echo "build --incompatible_linkopts_to_linklibs" >> /root/.bazelrc
+echo "build --incompatible_linkopts_to_linklibs --jobs=4" >> /root/.bazelrc
 
 if [[ -n "${RAY_INSTALL_JAVA:-}" ]]; then
   bazel build //java:ray_java_pkg

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -37,7 +37,7 @@ export JAVA_HOME="$java_home"
 
 WORK_DIR=${WORK_DIR:-}
 if [[ -z "${WORK_DIR}" ]]; then
-  echo "Project home not set"
+  echo "WORK_DIR not set"
   WORK_DIR="/ray"
 fi
 

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -42,6 +42,7 @@ $WORK_DIR/ci/env/install-bazel.sh
 # If converting down to manylinux2010, the following configuration should
 # be set for bazel
 #echo "build --config=manylinux2010" >> /root/.bazelrc
+# we limit to running 4 parallel jobs as we run into OOM in CCI if we just let it run wild.
 echo "build --incompatible_linkopts_to_linklibs --jobs=4" >> /root/.bazelrc
 
 if [[ -n "${RAY_INSTALL_JAVA:-}" ]]; then

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -35,12 +35,6 @@ echo "java_bin path $java_bin"
 java_home=${java_bin%jre/bin/java}
 export JAVA_HOME="$java_home"
 
-WORK_DIR=${WORK_DIR:-}
-if [[ -z "${WORK_DIR}" ]]; then
-  echo "WORK_DIR not set"
-  WORK_DIR="/ray"
-fi
-
 $WORK_DIR/ci/env/install-bazel.sh
 # Put bazel into the PATH if building Bazel from source
 # export PATH=/root/bazel-3.2.0/output:$PATH:/root/bin


### PR DESCRIPTION
- update bazel to just run 4 jobs at a time. Builds were failing to OOM
- update build macos script to comment out python 3.6, 3.7, 3.8 since builds were failing due to `dyld: Library not loaded:image not found` error. As we do not need them, we just need python 3.9 and 3.10
- update build manylinux 